### PR TITLE
Handle lowercase tokens and expand CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pip install -r requirements.txt
 
 > [!WARNING]
 > **For GPU Users (Manual PyTorch Installation Required):**
-> 1. First, prepare the dependency file. Open `requirements.txt, comment out the line for `torch` by adding a `#` at the beginning, and save the file.
+> 1. First, prepare the dependency file. Open `requirements.txt`, comment out the line for `torch` by adding a `#` at the beginning, and save the file.
 > ```txt
 > numpy==1.26.3
 > pandas==2.2.2

--- a/deepkoala/deepkoala.py
+++ b/deepkoala/deepkoala.py
@@ -29,10 +29,13 @@ class ProteinDataset(Dataset):
             return [entry for entry in entries if entry.strip()]
 
     def tokenize(self, sequence: str):
-        aa_vocab = {'<pad>': 0, '<unk>': 1, 'A': 2, 'C': 3, 'D': 4, 'E': 5, 
-                    'F': 6, 'G': 7, 'H': 8, 'I': 9, 'K': 10, 'L': 11, 
-                    'M': 12, 'N': 13, 'P': 14, 'Q': 15, 'R': 16, 'S': 17, 
-                    'T': 18, 'V': 19, 'W': 20, 'Y': 21}
+        sequence = sequence.upper()
+        aa_vocab = {
+            '<pad>': 0, '<unk>': 1, 'A': 2, 'C': 3, 'D': 4, 'E': 5,
+            'F': 6, 'G': 7, 'H': 8, 'I': 9, 'K': 10, 'L': 11,
+            'M': 12, 'N': 13, 'P': 14, 'Q': 15, 'R': 16, 'S': 17,
+            'T': 18, 'V': 19, 'W': 20, 'Y': 21
+        }
         return [aa_vocab.get(aa, 1) for aa in sequence]
 
     def __len__(self):
@@ -197,7 +200,10 @@ if __name__ == '__main__':
     parser.add_argument('--input_path', '-i', required=True, type=str, help='Input file path (fasta format)')
     parser.add_argument('--output_path', '-o', required=True, type=str, help='Output file path')
     parser.add_argument('--mode', '-m', default='full_length', choices=['full_length', 'metagenome'], type=str, help='Complete protein sequence or protein sequence in metagenome')
-    parser.add_argument('--date', '-d', default='latest', type=str, help='Specify the database version by month in the format YYYYMM')
+    parser.add_argument(
+        '--date', '-d', default='latest', type=str,
+        help="Specify the database version by month in the format YYYYMM or 'latest'"
+    )
     parser.add_argument('--batch_size', '-bs', default=64, type=int, help='Batch size')
     parser.add_argument('--num_workers', '-nw', default=0, type=int, help='DataLoader workers for inference')
     parser.add_argument('--output_format', '-of', default='simple', choices=['simple', 'detail'], type=str, help='Output detail level: simple (default) or detail')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,20 @@
+import importlib.util
+import pathlib
+import pytest
+
+
+spec = importlib.util.spec_from_file_location(
+    "deepkoala_module",
+    pathlib.Path(__file__).resolve().parents[1] / "deepkoala" / "deepkoala.py",
+)
+deepkoala = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(deepkoala)
+
+ProteinDataset = deepkoala.ProteinDataset
+
+
+def test_tokenize_handles_lowercase(tmp_path):
+    fasta = tmp_path / "sample.fasta"
+    fasta.write_text(">seq1\nACD\n")
+    dataset = ProteinDataset(str(fasta))
+    assert dataset.tokenize("acd") == [2, 3, 4]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+import importlib.util
+import pathlib
+import pytest
+
+
+spec = importlib.util.spec_from_file_location(
+    "deepkoala_module",
+    pathlib.Path(__file__).resolve().parents[1] / "deepkoala" / "deepkoala.py",
+)
+deepkoala = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(deepkoala)
+
+find_latest_date = deepkoala.find_latest_date
+
+
+def test_find_latest_date_latest(tmp_path):
+    (tmp_path / "202401").mkdir()
+    (tmp_path / "202402").mkdir()
+    result = find_latest_date("latest", str(tmp_path))
+    assert result == "202402"
+
+
+def test_find_latest_date_specific(tmp_path):
+    (tmp_path / "202401").mkdir()
+    result = find_latest_date("202401", str(tmp_path))
+    assert result == "202401"
+
+
+def test_find_latest_date_invalid_format(tmp_path):
+    with pytest.raises(SystemExit):
+        find_latest_date("20-01", str(tmp_path))


### PR DESCRIPTION
## Summary
- Normalize sequences to uppercase before tokenization so lowercase amino acids are processed correctly
- Clarify `--date` CLI help to mention the "latest" option
- Fix README formatting around GPU setup instructions
- Add tests for case-insensitive tokenization and date resolution logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b550c198ac832883a31d6bc62c7a6b