### PR TITLE
Require explicit profiles directory for precision mode

### DIFF
--- a/deepkoala/cli.py
+++ b/deepkoala/cli.py
@@ -24,6 +24,8 @@ def main():
     args = p.parse_args()
     try:
         if args.precision:
+            if not args.profiles_dir:
+                raise ValueError('--profiles_dir must be provided when --precision is enabled')
             profiles_dir = args.profiles_dir
             stats = inference_precision(
                 input_path=args.input_path,

--- a/deepkoala/infer_precision.py
+++ b/deepkoala/infer_precision.py
@@ -20,9 +20,6 @@ __all__ = [
 ]
 
 
-DEFAULT_PROFILES_DIR = "/usr/appli/freeware/kofamscan/1.3.0/db/profiles"
-
-
 @dataclass
 class DomainHit:
     """Container describing a detected domain on the original sequence."""
@@ -201,8 +198,10 @@ def annotate_precision(
     """Annotate domains in ``sequence`` using precision mode."""
 
     device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if not hmmer_dir:
+        raise ValueError("hmmer_dir must be provided for precision annotation")
     model, _, idx2ko, thresholds = _load_model(mode, date, device)
-    hmm_dir = Path(hmmer_dir or DEFAULT_PROFILES_DIR)
+    hmm_dir = Path(hmmer_dir)
 
     with torch.no_grad():
         hits = _annotate_sequence(sequence, model, idx2ko, thresholds, hmm_dir, device)
@@ -232,8 +231,10 @@ def inference_precision(
     """Run precision inference on ``input_path`` and write CSV to ``output_path``."""
 
     device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if not profiles_dir:
+        raise ValueError("profiles_dir must be provided when running precision inference")
     model, _, idx2ko, thresholds = _load_model(mode, date, device)
-    hmm_dir = Path(profiles_dir or DEFAULT_PROFILES_DIR)
+    hmm_dir = Path(profiles_dir)
 
     total_sequences = 0
     annotated_sequences = 0


### PR DESCRIPTION
## Summary
- remove the hard-coded default KOfam profiles directory from precision inference
- require the CLI to provide --profiles_dir when precision mode is enabled
- raise explicit errors in precision helpers when the profiles directory is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5f83997e883288716e2e853710d50