### PR TITLE
Handle hmmsearch no-hit exit code

### DIFF
--- a/deepkoala/infer_precision.py
+++ b/deepkoala/infer_precision.py
@@ -87,6 +87,10 @@ def _run_hmmsearch(hmm_file: Path, seq: str) -> Tuple[int | None, int | None]:
         except FileNotFoundError:
             print("hmmsearch not found; skipping boundary detection.")
             return None, None
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode == 1:
+                return None, None
+            raise
         domtbl.seek(0)
         for line in domtbl:
             if line.startswith("#"):

--- a/tests/test_infer_precision.py
+++ b/tests/test_infer_precision.py
@@ -1,0 +1,50 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from deepkoala import infer_precision
+
+
+def test_run_hmmsearch_returns_none_on_no_hits(monkeypatch, tmp_path):
+    hmm_file = tmp_path / "dummy.hmm"
+    hmm_file.write_text("")
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    start, end = infer_precision._run_hmmsearch(hmm_file, "A" * 60)
+
+    assert start is None and end is None
+
+
+def test_annotate_sequence_fallback_without_hmm_bounds(monkeypatch, tmp_path):
+    sequence = "A" * 60
+    hmm_dir = tmp_path
+    hmm_file = hmm_dir / "KO.hmm"
+    hmm_file.write_text("")
+
+    monkeypatch.setattr(infer_precision, "_classify", lambda *args, **kwargs: (0, 0.9))
+    monkeypatch.setattr(infer_precision, "_run_hmmsearch", lambda *args, **kwargs: (None, None))
+
+    model = object()
+    idx2ko = {0: "KO"}
+    thresholds = {"KO": 0.1}
+
+    hits = infer_precision._annotate_sequence(
+        sequence,
+        model,
+        idx2ko,
+        thresholds,
+        hmm_dir,
+        None,
+    )
+
+    assert len(hits) == 1
+    assert hits[0].start == 1
+    assert hits[0].end == len(sequence)


### PR DESCRIPTION
## Summary
- handle hmmsearch exit code 1 by returning fallback boundaries while preserving other errors
- add tests covering hmmsearch no-hit handling and annotate fallback behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d612457c788328830c2d703bdfaa27