### PR TITLE
Fix resource path resolution and document Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,43 @@ python3 -m deepkoala.cli -i metagenome.fasta -o detailed_results.csv --model fra
 > 2. Download `profiles.tar.gz` from [KOfam](https://www.genome.jp/ftp/db/kofam/archives/2025-02-01/) and extract it.
 > 3. Write the path of the extracted folder into the default value at line 21 of `deepkoala/cli.py`.
 > ```python
->     p.add_argument(
->       '--profiles_dir',
->       '-pd',
->       default='',     # <-- replace with your actual path
->       help='Directory containing KO-specific HMM profiles (multi-domain mode only)',
->   )
+    p.add_argument(
+      '--profiles_dir',
+      '-pd',
+      default='',     # <-- replace with your actual path
+      help='Directory containing KO-specific HMM profiles (multi-domain mode only)',
+  )
 > ```
+
+### Python API
+
+DeepKOALA can also be called programmatically when you want to integrate KO assignment inside a larger Python workflow. The
+weights and KO configuration files are automatically located from the installed package, so you can run inference from any
+working directory.
+
+```python
+from deepkoala.infer import inference
+from deepkoala.infer_multi import annotate_precision
+
+# Simple single-model prediction written to CSV
+stats = inference(
+    input_path="input.fasta",
+    output_path="results.csv",
+    model="full",        # or "frag"
+    topk=3,               # emit top-3 predictions per sequence
+    detail=True,          # include probabilities and thresholds
+)
+
+# Multi-domain mode for a single sequence (requires HMM profiles)
+hits = annotate_precision(
+    sequence="MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR",
+    hmmer_dir="/path/to/profiles",
+    model="full",
+)
+```
+
+* `deepkoala.infer.inference` mirrors the CLI options (`--model`, `--date`, `--batch_size`, `--num_workers`, `--detail`, `--topk`) and writes the results to `output_path`. It returns a summary dictionary with the total and annotated sequence counts.
+* `deepkoala.infer_multi.annotate_precision` returns a list of domain hits for a single sequence, each including the KO, probability, threshold, and domain boundaries when available.
 
 ## How to Cite
 

--- a/deepkoala/data.py
+++ b/deepkoala/data.py
@@ -1,33 +1,68 @@
 from torch.utils.data import Dataset, DataLoader
 from torch.nn.utils.rnn import pad_sequence
-import torch, re
+import torch
 
-AA_VOCAB = {'<pad>':0,'<unk>':1,'A':2,'C':3,'D':4,'E':5,'F':6,'G':7,'H':8,'I':9,
-            'K':10,'L':11,'M':12,'N':13,'P':14,'Q':15,'R':16,'S':17,'T':18,'V':19,'W':20,'Y':21}
+AA_VOCAB = {
+    '<pad>': 0,
+    '<unk>': 1,
+    'A': 2,
+    'C': 3,
+    'D': 4,
+    'E': 5,
+    'F': 6,
+    'G': 7,
+    'H': 8,
+    'I': 9,
+    'K': 10,
+    'L': 11,
+    'M': 12,
+    'N': 13,
+    'P': 14,
+    'Q': 15,
+    'R': 16,
+    'S': 17,
+    'T': 18,
+    'V': 19,
+    'W': 20,
+    'Y': 21,
+}
+
 
 class ProteinDataset(Dataset):
     def __init__(self, fasta_path: str):
         self.fasta_path = fasta_path
         self.entries = self._load()
+
     def _load(self):
         with open(self.fasta_path, 'r') as f:
             content = f.read()[1:]
         return [e for e in content.split('\n>') if e.strip()]
+
     def tokenize(self, seq: str):
         return [AA_VOCAB.get(a, 1) for a in seq]
-    def __len__(self): return len(self.entries)
+
+    def __len__(self):
+        return len(self.entries)
+
     def __getitem__(self, idx):
         header, seq = self.entries[idx].split('\n', 1)
         name = header.split(' ')[0]
-        seq = self.tokenize(seq.replace('\n',''))
+        seq = self.tokenize(seq.replace('\n', ''))
         t = torch.tensor(seq, dtype=torch.long)
-        return name, t, len(t)-1
+        return name, t, len(t) - 1
+
 
 def collate_fn(batch):
     names, seqs, lens = zip(*batch)
     padded = pad_sequence(seqs, batch_first=True, padding_value=0)
     return names, padded, torch.tensor(lens, dtype=torch.long)
 
-def get_dataloader(path: str, batch_size: int, num_workers: int=0):
-    return DataLoader(ProteinDataset(path), batch_size=batch_size, collate_fn=collate_fn,
-                      pin_memory=True, num_workers=num_workers)
+
+def get_dataloader(path: str, batch_size: int, num_workers: int = 0):
+    return DataLoader(
+        ProteinDataset(path),
+        batch_size=batch_size,
+        collate_fn=collate_fn,
+        pin_memory=True,
+        num_workers=num_workers,
+    )

--- a/deepkoala/infer.py
+++ b/deepkoala/infer.py
@@ -19,11 +19,11 @@ def inference(
 ):
     
     device = device or torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    resources_dir = "./resources"
+    resources_dir = Path(__file__).resolve().parent.parent / "resources"
 
     db_date = find_latest_date(date, resources_dir)
-    ko_cfg = Path(resources_dir)/db_date/f"ko_config_{model}.json"
-    weights = Path(resources_dir)/db_date/f"weights_{model}.pt"
+    ko_cfg = resources_dir / db_date / f"ko_config_{model}.json"
+    weights = resources_dir / db_date / f"weights_{model}.pt"
 
     ko2idx, idx2ko, threshold = load_ko_config(str(ko_cfg))
     model = GRUClassifier(128, 2, len(ko2idx)).to(device)

--- a/deepkoala/model.py
+++ b/deepkoala/model.py
@@ -1,15 +1,18 @@
-import torch, torch.nn as nn, torch.nn.functional as F
+import torch
+import torch.nn as nn
+
 
 class GRUClassifier(nn.Module):
-    def __init__(self, hidden:int, layers:int, n_cls:int):
+    def __init__(self, hidden: int, layers: int, n_cls: int):
         super().__init__()
         self.embed = nn.Embedding(22, 16, padding_idx=0)
-        self.rnn   = nn.GRU(16, hidden, num_layers=layers)
-        self.ffn   = nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU())
-        self.cls   = nn.Linear(hidden, n_cls)
+        self.rnn = nn.GRU(16, hidden, num_layers=layers)
+        self.ffn = nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU())
+        self.cls = nn.Linear(hidden, n_cls)
+
     def forward(self, x, lens):
-        x = self.embed(x).permute(1,0,2).contiguous()
-        x,_ = self.rnn(x)
+        x = self.embed(x).permute(1, 0, 2).contiguous()
+        x, _ = self.rnn(x)
         idx = torch.arange(lens.size(0), device=lens.device)
-        x  = x[lens, idx]
+        x = x[lens, idx]
         return self.cls(self.ffn(x))


### PR DESCRIPTION
## Summary
- resolve resource directory using the package path so inference works from any working directory
- clean up dataset/model modules formatting while keeping behavior unchanged
- add README guidance for calling DeepKOALA from Python, including multi-domain helpers

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fa031e0388328a1c0cc5c35f44cef)