### PR TITLE
Add unified CPU/CUDA/MPS device resolver and CLI `--device` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ pip install -r requirements.txt
 > ```bash
 > pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cu121
 > ```
+>
+> **For Apple Silicon Users:** install a macOS PyTorch build with MPS support. DeepKOALA can automatically detect MPS with `--device auto` (the default), or you can explicitly select it with `--device mps`.
 
 ### 4. Download Pre-trained Models
 
@@ -129,6 +131,12 @@ To annotate metagenomic genes using the specialized model and get a detailed out
 python3 -m deepkoala.cli -i metagenome.fasta -o detailed_results.csv --model frag --detail
 ```
 
+On an Apple Silicon Mac with an MPS-enabled PyTorch build, you can explicitly run inference on the Apple GPU:
+
+```bash
+python3 -m deepkoala.cli -i my_proteins.fasta -o results.csv --device mps
+```
+
 ### Command-Line Options
 
 * `--input_path` `-i`: Path to the input protein FASTA file. **(Required)**
@@ -139,6 +147,7 @@ python3 -m deepkoala.cli -i metagenome.fasta -o detailed_results.csv --model fra
 * `--date` `-d`: Specifies the version of the pre-trained model to use. (Default: `latest`, which loads the latest available model).
 * `--batch_size` `-bs`: Number of sequences to process in a single batch. Larger values can be faster on GPUs but use more memory. (Default: `32`).
 * `--num_workers` `-nw`: Number of worker processes for data loading. Can accelerate processing on some systems. (Default: `2`).
+* `--device`: Selects the inference device: `auto`, `cpu`, `cuda`, or `mps`. The default `auto` mode prefers CUDA, then Apple Silicon MPS, and finally CPU. Explicitly requested unavailable backends produce an error instead of silently falling back.
 * `--detail`: Emit a detailed output format instead of the simple default.
   * **Default (simple)**: A concise format that only shows the predicted KO label (`predict_label`) for sequences that meet the confidence threshold. Other predictions are left blank.
 
@@ -207,7 +216,7 @@ hits = annotate_precision(
 )
 ```
 
-* `deepkoala.infer.inference` mirrors the CLI options (`--model`, `--date`, `--batch_size`, `--num_workers`, `--detail`, `--topk`) and writes the results to `output_path`. It returns a summary dictionary with the total and annotated sequence counts.
+* `deepkoala.infer.inference` mirrors the CLI options (`--model`, `--date`, `--batch_size`, `--num_workers`, `--device`, `--detail`, `--topk`) and writes the results to `output_path`. It returns a summary dictionary with the total and annotated sequence counts.
 * `deepkoala.infer_multi.annotate_precision` returns a list of domain hits for a single sequence, each including the KO, probability, threshold, and domain boundaries when available.
 
 ## Citation

--- a/deepkoala/cli.py
+++ b/deepkoala/cli.py
@@ -20,6 +20,12 @@ def main():
     p.add_argument('--batch_size', '-bs', type=int, default=32, help='Batch size for batched inference')
     p.add_argument('--num_workers', '-nw', type=int, default=2, help='Number of dataloader worker processes')
     p.add_argument(
+        '--device',
+        choices=['auto', 'cpu', 'cuda', 'mps'],
+        default='auto',
+        help='Inference device; auto prefers CUDA, then MPS, then CPU',
+    )
+    p.add_argument(
         '--detail',
         action='store_true',
         help='Use detailed output format (include probabilities, thresholds, and boundaries where applicable)',
@@ -45,6 +51,7 @@ def main():
                 date=args.date,
                 profiles_dir=profiles_dir,
                 detail=args.detail,
+                device=args.device,
                 topk=args.topk,
             )
 
@@ -60,6 +67,7 @@ def main():
                 batch_size=args.batch_size,
                 num_workers=args.num_workers,
                 detail=args.detail,
+                device=args.device,
                 topk=args.topk,
             )
         print(f"Processed {stats['total']} sequences, annotated {stats['annotated']}.")

--- a/deepkoala/infer.py
+++ b/deepkoala/infer.py
@@ -4,7 +4,7 @@ import pandas as pd
 from tqdm import tqdm
 from .data import get_dataloader
 from .model import GRUClassifier
-from .utils import load_ko_config, find_latest_date
+from .utils import find_latest_date, load_ko_config, resolve_device
 
 def inference(
     input_path: str,
@@ -14,11 +14,11 @@ def inference(
     batch_size: int = 64,
     num_workers: int = 2,
     detail: bool = False,
-    device: torch.device | None = None,
+    device: str | torch.device | None = None,
     topk: int = 1,
 ):
     
-    device = device or torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = resolve_device(device)
     resources_dir = Path(__file__).resolve().parent.parent / "resources"
 
     db_date = find_latest_date(date, resources_dir)

--- a/deepkoala/infer_multi.py
+++ b/deepkoala/infer_multi.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 
 from .data import AA_VOCAB
 from .model import GRUClassifier
-from .utils import find_latest_date, load_ko_config
+from .utils import find_latest_date, load_ko_config, resolve_device
 
 __all__ = [
     "annotate_precision",
@@ -228,11 +228,11 @@ def annotate_precision(
     hmmer_dir: str | None = None,
     date: str = "latest",
     model: str = "full",
-    device: torch.device | None = None,
+    device: str | torch.device | None = None,
 ) -> List[Dict[str, float]]:
     """Annotate domains in ``sequence`` using multi-domain mode."""
 
-    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = resolve_device(device)
     if not hmmer_dir:
         raise ValueError("hmmer_dir must be provided for multi-domain annotation")
     classifier, _, idx2ko, thresholds = _load_model(model, date, device)
@@ -261,12 +261,12 @@ def inference_precision(
     date: str = "latest",
     profiles_dir: str | None = None,
     detail: bool = False,
-    device: torch.device | None = None,
+    device: str | torch.device | None = None,
     topk: int = 1,
 ) -> Dict[str, object]:
     """Run multi-domain inference on ``input_path`` and write CSV to ``output_path``."""
 
-    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = resolve_device(device)
     if not profiles_dir:
         raise ValueError("profiles_dir must be provided when running multi-domain inference")
     if topk < 1:

--- a/deepkoala/utils.py
+++ b/deepkoala/utils.py
@@ -1,6 +1,41 @@
 import os, re, sys, json
 from typing import Dict, Tuple
 
+import torch
+
+
+def _mps_is_available() -> bool:
+    return hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+
+
+def resolve_device(device: str | torch.device | None = None) -> torch.device:
+    """Resolve an inference device, validating explicitly requested backends."""
+
+    if device is None or device == "auto":
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if _mps_is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    try:
+        resolved = torch.device(device)
+    except (RuntimeError, TypeError) as exc:
+        raise ValueError(
+            f"Unsupported device '{device}'; choose one of: auto, cpu, cuda, mps"
+        ) from exc
+
+    if resolved.type == "cuda" and not torch.cuda.is_available():
+        raise ValueError("Requested device 'cuda' is not available")
+    if resolved.type == "mps" and not _mps_is_available():
+        raise ValueError("Requested device 'mps' is not available")
+    if resolved.type not in {"cpu", "cuda", "mps"}:
+        raise ValueError(
+            f"Unsupported device '{device}'; choose one of: auto, cpu, cuda, mps"
+        )
+    return resolved
+
+
 def load_ko_config(json_path: str):
     with open(json_path, "r", encoding="utf-8") as f:
         classes = json.load(f)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,12 @@
 import subprocess
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from deepkoala import cli
 
 def test_cli_with_fixed_fasta(tmp_path: Path):
     # 1. Locate the fixed input FASTA file under tests/
@@ -41,3 +48,52 @@ def test_cli_help():
     )
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()
+
+
+def test_cli_passes_device_to_inference(monkeypatch, tmp_path):
+    received = {}
+
+    def fake_inference(**kwargs):
+        received.update(kwargs)
+        return {"total": 0, "annotated": 0}
+
+    monkeypatch.setattr(cli, "inference", fake_inference)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["deepkoala", "-i", "input.fasta", "-o", str(tmp_path / "out.csv"), "--device", "mps"],
+    )
+
+    cli.main()
+
+    assert received["device"] == "mps"
+
+
+def test_cli_passes_device_to_multi_domain_inference(monkeypatch, tmp_path):
+    received = {}
+
+    def fake_inference_precision(**kwargs):
+        received.update(kwargs)
+        return {"total": 0, "annotated": 0}
+
+    monkeypatch.setattr(cli, "inference_precision", fake_inference_precision)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "deepkoala",
+            "-i",
+            "input.fasta",
+            "-o",
+            str(tmp_path / "out.csv"),
+            "--multi",
+            "--profiles_dir",
+            "profiles",
+            "--device",
+            "cpu",
+        ],
+    )
+
+    cli.main()
+
+    assert received["device"] == "cpu"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from deepkoala.utils import resolve_device
+
+
+def set_backend_availability(monkeypatch, *, cuda: bool, mps: bool) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: mps)
+
+
+def test_resolve_device_auto_prefers_cuda(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=True, mps=True)
+
+    assert resolve_device("auto") == torch.device("cuda")
+
+
+def test_resolve_device_auto_uses_mps_when_cuda_is_unavailable(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=False, mps=True)
+
+    assert resolve_device(None) == torch.device("mps")
+
+
+def test_resolve_device_auto_uses_cpu_when_accelerators_are_unavailable(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=False, mps=False)
+
+    assert resolve_device("auto") == torch.device("cpu")
+
+
+def test_resolve_device_rejects_explicit_unavailable_mps(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=False, mps=False)
+
+    with pytest.raises(ValueError, match="mps"):
+        resolve_device("mps")
+
+
+def test_resolve_device_accepts_explicit_cpu(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=False, mps=False)
+
+    assert resolve_device("cpu") == torch.device("cpu")
+
+
+def test_resolve_device_accepts_explicit_available_cuda(monkeypatch):
+    set_backend_availability(monkeypatch, cuda=True, mps=False)
+
+    assert resolve_device(torch.device("cuda")) == torch.device("cuda")


### PR DESCRIPTION
### Motivation

- Centralize and standardize inference device selection to avoid duplicated logic and to make behavior explicit for `cuda`, `mps`, `cpu` and `auto` choices.
- Ensure explicit requests for unavailable backends raise clear errors instead of silently falling back.

### Description

- Add `resolve_device(device: str | torch.device | None) -> torch.device` in `deepkoala/utils.py` that implements `auto` selection order `cuda → mps → cpu` and validates explicit `cuda`/`mps` availability, raising `ValueError` with the device name on error.
- Replace ad-hoc device selection in `deepkoala/infer.py` and `deepkoala/infer_multi.py` with calls to `resolve_device` and update the function signatures to accept `str | torch.device | None` for `device`.
- Add a `--device` CLI argument to `deepkoala/cli.py` with choices `auto`, `cpu`, `cuda`, `mps` (default `auto`) and pass the parsed value through to both single-model and multi-domain inference entry points.
- Update `README.md` installation and usage notes to document Apple Silicon (MPS) usage and the `--device` option (including an example `--device mps`).
- Add unit tests: `tests/test_utils.py` provides isolated `resolve_device` coverage via `monkeypatch` for CUDA/MPS/CPU and explicit-unavailable error; `tests/test_cli.py` was extended to assert that the CLI forwards `device` to both inference functions.

### Testing

- Ran `python -m compileall -q deepkoala tests` and the code compiled successfully.
- Performed static/diff checks (`git diff --check`) with no problems detected.
- Attempted `pytest` for `tests/test_utils.py`, `tests/test_cli.py`, and existing `tests/test_infer_precision.py`, but test collection failed in this environment because `torch` and `pandas` are not installed; the new tests are unit/isolated and use `monkeypatch` but still import `torch` so they require an environment with PyTorch available to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b2be02d288328a1998a4418900972)